### PR TITLE
Added Yolo-style annotation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ For more details, we refer to our [paper](https://mediatum.ub.tum.de/doc/1578845
 ### Data
 The annotated dataset can be downloaded [here](https://go.mytum.de/239870). Furthermore, we also provide additional data (not annotated) [here](http://go.mytum.de/928009).
 ### Annotations 
-Annotations are stored in [COCO format](https://cocodataset.org/#format-data) under `rgb/loco-all-v1.json`. For ease of use, we also provide seperate annotation files for each subset. 
+Annotations are stored in [COCO format](https://cocodataset.org/#format-data) under `rgb/loco-all-v1.json`. For ease of use, we also provide seperate annotation files for each subset.
+### Annotations in YOLO format
+For ease of use two scripts are added which can automate the dataset download (`get_loco.sh`) and transform the data anotation to the YOLO format (`transform_to_yolo_format.py`)
 
 ## Credits & How to cite
 This project would not have been possible without the amazing team including Dimitrij-Marian Holm, Benjamin Molter, Nikolai Ruof and Mubashir Hanif as well as all the hardworking annotators.

--- a/scripts/get_loco.sh
+++ b/scripts/get_loco.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# LOCO 2020 dataset https://webdisk.ads.mwn.de/Handlers/AnonymousDownload.ashx?folder=73e976ba&path=LOCO%5Cv1
+# Download command: bash ./scripts/get_loco.sh
+
+# Note: This script downloads the LOCO dataset and labels and saves them in the following structure:
+# |--loco
+# |  |--images
+# |  |  |--train
+# |  |  |  |--subset-2
+# |  |  |  |--subset-3
+# |  |  |  |--subset-5
+# |  |  |--val
+# |  |  |  |--subset-1
+# |  |  |  |--subset-4
+# |  |--labels
+# |  |  |--train
+# |  |  |  |--loco-sub2-v1-train.json
+# |  |  |  |--loco-sub3-v1-train.json
+# |  |  |  |--loco-sub5-v1-train.json
+# |  |  |--val
+# |  |  |  |--loco-sub1-v1-val.json
+# |  |  |  |--loco-sub4-v1-val.json
+# The dataset structure inside the subsets is left unchanged.
+
+## Download/unzip labels
+
+d='./loco/labels'
+url='https://github.com/tum-fml/loco/archive/refs/heads/master.zip'
+f='loco-master.zip'
+echo 'Downloading labels from: ' $url$f
+curl -L $url -o $f && unzip -q $f && rm -r $f # download, unzip, remove in background
+
+# Move labels to correct directory
+mkdir -p $d/train
+mkdir -p $d/val
+mv ./loco-main/rgb/* $d
+find $d -type f -name '*train*' -exec mv {} $d/train \; 2>/dev/null
+find $d -type f -name '*val*' -exec mv {} $d/val \; 2>/dev/null
+rm $d/loco-all-v1.json  # removing this file as I am later not using it. In case you need it, comment this line
+
+wait # finish background tasks
+rm -rf ./loco-main
+echo -e '\nFinished downloading labels\n---\n'
+
+## Download/unzip images
+
+d='./loco/images' # unzip directory
+# unshortened link: https://webdisk.ads.mwn.de/Handlers/AnonymousDownload.ashx?folder=73e976ba&path=LOCO%5Cv1%5Cdataset.zip
+url='https://go.mytum.de/239870'
+f='dataset.zip'
+echo 'Downloading datasets from: ' $url
+curl -L $url -o $f && unzip -q $f && rm -r $f # download, unzip, remove in background
+
+set1='subset-1'     # validation
+set2='subset-2'     # training
+set3='subset-3'     # training
+set4='subset-4'     # validation
+set5='subset-5'     # training
+
+# Move images to correct directory
+mkdir -p $d/train
+mkdir -p $d/val
+# train directory
+for set in $set2 $set3 $set5; do
+    mv ./dataset/$set $d/train
+done
+# val directory
+for set in $set1 $set4; do
+    mv ./dataset/$set $d/val
+done
+
+wait # finish background tasks
+rm -rf ./dataset
+echo -e '\nFinished downloading LOCO dataset\n---\n'

--- a/scripts/transform_to_yolo_format.py
+++ b/scripts/transform_to_yolo_format.py
@@ -1,0 +1,231 @@
+"""
+This script converts annotation data from LOCO format (COCO based) to YOLO format. It has two options:
+1. Extracting the images from subdirectories inside the `image` directory and moving them all in the root of `image`.
+    If a custom data split inside `images` of train, val and test is present the script will maintain this structure.
+2. Converting the annotations in JSON format (COCO style) to YOLO format.
+    Additionally it creates a `loco.yaml` file in the root of the dataset folder with the class names.
+
+Parameters
+----------
+DIR : str
+    Directory path to dataset folder. It should contain the subdirectories `images` and `labels` with the images and annotations in COCO format.
+    This option must be provided in order for the script to work.
+convertImages : bool
+    If set to True, the script will extract images from subdirectories inside the `images` directory and move them all in the root of `images`.
+    If a custom data split inside `images` of train, val and test is present the script will maintain this structure.
+    Default is False.
+convert2yolo : bool
+    If set to True, the script will convert dataset annotations from COCO to YOLO format.
+    Default is False.
+"""
+
+import shutil, os
+import argparse
+import json
+import shutil
+from tqdm import tqdm
+
+def convert_bbox_coco2yolo(img_width, img_height, bbox):
+    """
+    Convert bounding box from COCO  format to YOLO format
+
+    Parameters
+    ----------
+    img_width : int
+        width of image
+    img_height : int
+        height of image
+    bbox : list[int]
+        bounding box annotation in COCO format:
+        [top left x position, top left y position, width, height]
+
+    Returns
+    -------
+    list[float]
+        bounding box annotation in YOLO format:
+        [x_center_rel, y_center_rel, width_rel, height_rel]
+    """
+
+    # YOLO bounding box format: [x_center, y_center, width, height]
+    # (float values relative to width and height of image)
+    x_tl, y_tl, w, h = bbox
+
+    dw = 1.0 / img_width
+    dh = 1.0 / img_height
+
+    x_center = x_tl + w / 2.0
+    y_center = y_tl + h / 2.0
+
+    x = x_center * dw
+    y = y_center * dh
+    w = w * dw
+    h = h * dh
+
+    return [x, y, w, h]
+
+def convert_classid_coco2yolo(loco_id):
+    """
+    Convert class ID from COCO to YOLO format
+
+    Parameters
+    ----------
+    loco_id : int
+        class ID in LOCO format
+
+    Returns
+    -------
+    int
+        class ID in YOLO format
+    """
+    # LOCO class IDs are not sorted, YOLO class IDs are 0-indexed
+    if loco_id == 3:
+        return 0
+    elif loco_id == 5:
+        return 1
+    elif loco_id == 7:
+        return 2
+    elif loco_id == 10:
+        return 3
+    elif loco_id == 11:
+        return 4
+    else:
+        raise ValueError(f"Unknown class ID {loco_id}")
+
+# This script is used to transform the dataset to the YOLO format
+# For use in GitHub Codespaces use '/workspaces' instead of content
+def transform_images_to_yolo_format(directory='/content/yolov9/loco/images'):
+    temp_dir = os.path.abspath(os.path.join(directory, '../', 'temp'))
+
+    # supported image extensions
+    image_extensions = {".jpg", ".jpeg"}
+    custom_structure = False
+
+    # check if the dataset is already in the YOLO format and keep the structure
+    if os.path.exists(os.path.join(directory, 'train')):
+        transform_images_to_yolo_format(os.path.join(directory, 'train'))
+        os.rename(os.path.join(directory, 'temp'), os.path.join(directory, 'train'))
+        custom_structure = True
+    if os.path.exists(os.path.join(directory, 'val')):
+        transform_images_to_yolo_format(os.path.join(directory, 'val'))
+        os.rename(os.path.join(directory, 'temp'), os.path.join(directory, 'val'))
+        custom_structure = True
+    if os.path.exists(os.path.join(directory, 'test')):
+        transform_images_to_yolo_format(os.path.join(directory, 'test'))
+        os.rename(os.path.join(directory, 'temp'), os.path.join(directory, 'test'))
+        custom_structure = True
+    if custom_structure:
+        print("Finished working on images with custom structure")
+        return
+
+    # copy all images to a temp directory
+    os.makedirs(temp_dir, exist_ok=True)
+    for dir_name, sub_dir_list, file_list in tqdm(os.walk(directory), desc=f"Sorting images in {directory}"):
+        for file_name in file_list:
+            if any(file_name.lower().endswith(ext) for ext in image_extensions):
+                source = os.path.join(dir_name, file_name)
+                destination = os.path.join(temp_dir, file_name)
+                shutil.move(source, destination)
+
+    shutil.rmtree(directory)
+
+def convert_json_to_yolo_txt(directory):
+
+    # write labels, which holds names of all classes (one class per line)
+    # label_file = os.path.join(os.path.join(output_path, "../"), "labels.txt")
+    # with open(label_file, "w") as f:
+    #    for category in tqdm(json_data["categories"], desc="Categories"):
+    #        category_name = category["name"]
+    #        f.write(f"{category_name}\n")
+
+    custom_structure = False
+    if os.path.exists(os.path.join(directory, 'train')):
+        convert_json_to_yolo_txt(os.path.join(directory, 'train'))
+        custom_structure = True
+    if os.path.exists(os.path.join(directory, 'val')):
+        convert_json_to_yolo_txt(os.path.join(directory, 'val'))
+        custom_structure = True
+    if os.path.exists(os.path.join(directory, 'test')):
+        convert_json_to_yolo_txt(os.path.join(directory, 'test'))
+        custom_structure = True
+    if custom_structure:
+        print("Finished working on labels with custom structure")
+        return
+
+    json_files = [f for f in os.listdir(directory) if f.endswith('.json')]
+
+    for json_file in tqdm(json_files, desc=f"Converting JSON to YOLO in {directory}"):
+        with open(os.path.join(directory, json_file)) as f:
+            json_data = json.load(f)
+        for image in json_data["images"]:
+            img_id = image["id"]
+            img_name = image["file_name"]
+            img_width = image["width"]
+            img_height = image["height"]
+
+            anno_in_image = [anno for anno in json_data["annotations"] if anno["image_id"] == img_id]
+            anno_txt = os.path.join(directory, img_name.split(".")[0] + ".txt")
+            with open(anno_txt, "w") as f:
+                for anno in anno_in_image:
+                    class_id = convert_classid_coco2yolo(anno["category_id"])
+                    bbox_COCO = anno["bbox"]
+                    x, y, w, h = convert_bbox_coco2yolo(img_width, img_height, bbox_COCO)
+                    f.write(f"{class_id} {x:.6f} {y:.6f} {w:.6f} {h:.6f}\n")
+        os.remove(os.path.join(directory, json_file))
+
+def create_loco_yaml(directory):
+    class_names = []
+    classes_found = False
+    for dir_name, sub_dir_list, file_list in os.walk(directory):
+        if classes_found:
+            break
+        for file in file_list:
+            if file.endswith('.json'):
+                with open(os.path.join(dir_name, file)) as f:
+                    json_data = json.load(f)
+                for category in json_data["categories"]:
+                    class_names.append(category["name"])
+                classes_found = True
+                break
+    
+    if os.path.exists(os.path.join(directory, 'loco.yaml')):
+        return
+    
+    with open(os.path.abspath(os.path.join(directory, '../../' 'loco.yaml')), 'w') as f:
+        if os.path.exists(os.path.join(directory, 'train')):
+            f.write(f"train: {os.path.abspath(os.path.join(directory, '../images/', 'train'))}\n")
+        else:
+            f.write(f"path: {directory}\n")
+        if os.path.exists(os.path.join(directory, 'val')):
+            f.write(f"val: {os.path.abspath(os.path.join(directory, '../images/', 'val'))}\n")
+        if os.path.exists(os.path.join(directory, 'test')):
+            f.write(f"test: {os.path.abspath(os.path.join(directory, '../images/', 'test'))}\n")
+        f.write('\nnc: 5\nnames:')
+        for i, name in enumerate(class_names):
+            f.write(f'\n  {i}: {name}')
+        
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    # for use in GitHub Codespaces use '/workspaces' as directory
+    # default is the google colab directory
+    parser.add_argument('--DIR', '--dir', '-d', type=str, help='Directory path to dataset folder', default='/content/yolov9/loco')
+    parser.add_argument('--convert2yolo', '-c2y', '--coco2yolo', action='store_true', help='Convert dataset annotation from COCO (JSON) to YOLO format')
+    parser.add_argument('--convertImages', '-cI', action='store_true', help='Extract images from subdirectories and move them to the root of the images directory')
+    args = parser.parse_args()
+    return args
+
+if __name__ == "__main__":
+    arg = parse_args()
+    if not os.path.exists(arg.DIR):
+        raise FileNotFoundError(f"Directory {arg.DIR} does not exist")
+    if arg.convertImages:
+        if os.path.exists(os.path.join(arg.DIR, 'images')):
+            transform_images_to_yolo_format(os.path.join(arg.DIR, 'images'))
+        else:
+            raise FileNotFoundError(f"Subdirectory 'images' not found in {arg.DIR}")
+    if arg.convert2yolo:
+        if os.path.exists(os.path.join(arg.DIR, 'labels')):
+            create_loco_yaml(os.path.join(arg.DIR, 'labels'))
+            convert_json_to_yolo_txt(os.path.join(arg.DIR, 'labels'))
+        else:
+            raise FileNotFoundError(f"Subdirectory 'labels' not found in {arg.DIR}")


### PR DESCRIPTION
For use with the YOLO detection algorithm I added a python script to transform the COCO style data annotation into the YOLO format and dealing with the required structure:

```
├──  loco
│   ├──  images
│   │   ├── train
│   │   │   ├── <train_ids>.jpg
│   │   ├── val
│   │   │   ├── <train_ids>.jpg
│   ├──  labels
│   │   ├── train
│   │   │   ├── <train_ids>.txt
│   │   ├── val
│   │   │   ├── <train_ids>.txt
```


- `get_loco.sh` is an automated script to download the data
- `transform_to_yolo_format.py` can deal with the different data annotation as well as moving all pictures out of subdirectories into a root directory, as required by the yolo algorithm. Additionally it automatically creates the required loco.yaml file based on the given categories in the .json annotated files.

This pull request is related to #6 